### PR TITLE
Add CI workflow for Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run cargo tests
+        run: cargo test --all --verbose
+
+      - name: Run rust coverage
+        run: |
+          cargo install cargo-tarpaulin
+          cargo tarpaulin --out Xml --timeout 120
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarpaulin-report
+          path: cobertura.xml


### PR DESCRIPTION
## Summary
- add a CI workflow that tests and collects coverage using cargo

## Testing
- `cargo --version`
- `cargo test` *(fails: environment lacks network access and dependencies need to be built)*

------
https://chatgpt.com/codex/tasks/task_e_683b6ffc1a8c832f817ca50b247c1c34