### PR TITLE
Fix correlated detection for fully-qualified names

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ async fn main() -> datafusion::error::Result<()> {
 ```
 
 The repository contains functional tests showing a complete in-memory example.
+
+## Development Notes
+
+The test suite now checks handling of fully qualified column names. The
+`find_correlated_columns` function inspects identifier parts to detect
+references to outer queries. It now examines the table component of compound
+identifiers so expressions like `schema.table.col` are not incorrectly treated
+as correlated when `table` is a local source.


### PR DESCRIPTION
## Summary
- fix alias lookup for compound identifiers when collecting correlated columns
- store table names without schema for alias detection
- add regression test for fully qualified identifiers
- document the change

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_683b7bffa6e0832fac5b62d680877f7d

<!-- greptile_comment -->

## Greptile Summary

Enhances correlation detection in SQL queries by fixing how fully-qualified identifiers (schema.table.column) are handled, preventing false positives and improving alias detection accuracy.

- Fixed correlation detection in `src/lib.rs` to properly parse compound identifiers, preventing incorrect matches with schema-qualified names
- Added regression tests in `src/lib.rs` specifically for fully-qualified identifier scenarios
- Modified table alias detection to strip schema prefixes for more accurate matching
- Updated `README.md` with new 'Development Notes' section explaining identifier correlation improvements



<sub>💡 (3/5) Reply to the bot's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a "Development Notes" section to the README to explain recent improvements in test coverage and handling of fully qualified column names.
- **Bug Fixes**
  - Improved detection of correlated columns to correctly handle fully qualified local column references, preventing them from being misidentified as correlated columns from outer queries.
- **Tests**
  - Added a new test to ensure fully qualified local column references are correctly handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->