### PR TITLE
Add MIT license and rewrite example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "df_subquery_udf"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [lib]
 path = "src/lib.rs"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 <placeholder>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 <placeholder>
+Copyright (c) 2025 <placeholder>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -27,6 +27,34 @@ async fn main() -> datafusion::error::Result<()> {
 }
 ```
 
+## Query Rewrite Example
+
+Given a query with a correlated subquery:
+
+```sql
+SELECT id FROM t1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.x = t1.x)
+```
+
+Running `rewrite_query` rewrites it to use a generated UDF:
+
+```sql
+SELECT id FROM t1 WHERE __subq0(t1.x)
+```
+
+During rewriting the library registers a UDF named `__subq0` whose body is the
+original subquery and whose arguments correspond to the referenced outer
+columns. The rewritten SQL can be executed normally once the function is
+registered in the `SessionContext`.
+
+## Implementation Details
+
+The transformation walks the parsed SQL AST looking for `EXISTS`, `IN` and
+standalone subqueries. When such a subquery references columns from the outer
+query, those columns become arguments to a newly created `ScalarUDF`. The UDF is
+registered on the provided `SessionContext` and the subquery expression is
+replaced by a call to this function. The return type of the function is inferred
+by planning the subquery with DataFusion.
+
 The repository contains functional tests showing a complete in-memory example.
 
 ## Development Notes


### PR DESCRIPTION
## Summary
- add MIT license
- document a query rewrite example and how the helper works
- describe implementation details
- declare the license in Cargo.toml

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683b8632afd8832f8ca6e7868c17669e

<!-- greptile_comment -->

## Greptile Summary

Added MIT license and enhanced documentation for the correlated subquery to UDF transformation library. This PR improves project documentation and licensing clarity.

- License file needs updates: Copyright year should be 2025 (not 2024) and `<placeholder>` needs actual copyright holder
- Added detailed query rewrite example in `README.md` showing transformation from correlated subqueries to UDFs
- Added implementation details section in `README.md` explaining AST transformation process
- Declared MIT license in `Cargo.toml` metadata
- Dependencies properly specified with DataFusion 47.0.0 and Arrow 55.1.0



<sub>💡 (4/5) You can add custom instructions or style guidelines for the bot [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a section to the README with examples and explanations of how correlated subqueries are rewritten into user-defined functions (UDFs), including implementation details.
  - Added the full text of the MIT License in a new LICENSE file.
- **Chores**
  - Explicitly declared the MIT license in project metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->