### PR TITLE
Fix UDF cleanup and name conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ use datafusion::prelude::SessionContext;
 async fn main() -> datafusion::error::Result<()> {
     let mut ctx = SessionContext::new();
     let sql = "select 1 where exists(select 1)";
-    let rewritten = rewrite_query(sql, &mut ctx).await?;
-    ctx.sql(&rewritten).await?.show().await
+    let (rewritten, udfs) = rewrite_query(sql, &mut ctx).await?;
+    ctx.sql(&rewritten).await?.show().await?;
+    for name in udfs {
+        ctx.deregister_udf(&name);
+    }
+    Ok(())
 }
 ```
 


### PR DESCRIPTION
## Summary
- generate unique names for registered UDFs
- track registered UDF names in `rewrite_query`
- deregister UDFs after execution
- update tests and documentation
- add test covering UDF cleanup

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683b8b079aec832f87a367ad1258e2c1

<!-- greptile_comment -->

## Greptile Summary

Implements robust UDF lifecycle management in the SQL query rewriter to prevent memory leaks and name conflicts in concurrent scenarios.

- Added atomic UDF name generation using `AtomicUsize` in `src/lib.rs` to ensure thread-safe unique identifiers
- Modified `rewrite_query` function to return both rewritten query and UDF names list for cleanup tracking
- Added automatic UDF deregistration after execution in `rewrite_and_exec` function
- Updated README.md with examples demonstrating proper UDF cleanup procedures
- Added comprehensive tests verifying UDF lifecycle management and cleanup functionality



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README example to reflect changes in function usage and UDF cleanup process.

- **New Features**
  - UDFs registered during query rewriting are now automatically deregistered after execution.

- **Bug Fixes**
  - Improved thread safety for UDF name generation.

- **Tests**
  - Added a test to verify UDF registration and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->