### PR TITLE
Enable execution of generated UDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,6 @@ The test suite now checks handling of fully qualified column names. The
 references to outer queries. It now examines the table component of compound
 identifiers so expressions like `schema.table.col` are not incorrectly treated
 as correlated when `table` is a local source.
+
+## Notes
+Implemented minimal execution for generated subquery UDFs. Each UDF now runs its stored query in a separate thread and substitutes parameters before execution. Tests verify that correlated subqueries return expected values.


### PR DESCRIPTION
## Summary
- implement basic execution logic for subquery UDFs
- run subquery in a dedicated thread and convert parameters
- add regression test covering correlated subquery execution
- document the new behaviour in the README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683d8e96ca34832f8491b29b95c9f84d

<!-- greptile_comment -->

## Greptile Summary

Implements core functionality for executing correlated subquery UDFs in DataFusion, including thread-safe execution and parameter value handling.

- Added thread-safe UDF execution logic in `src/lib.rs` with dedicated async runtimes for subqueries
- Implemented `scalar_to_sql` conversion function in `src/lib.rs` for translating DataFusion values to SQL literals
- Enhanced UDF registration in `src/lib.rs` to support EXISTS clauses and various return types
- Added comprehensive regression tests for correlated subquery execution
- Updated `README.md` with documentation on the new subquery UDF execution behavior



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with a new "Notes" section explaining minimal execution support for generated subquery UDFs, including details on threading, parameter substitution, and test confirmations for correlated subqueries.

- **New Features**
  - Added support for executing correlated subquery UDFs with dynamic parameter substitution and multi-threaded execution.
  - Enhanced subquery UDFs to handle SELECT EXISTS patterns and return appropriate Boolean results.

- **Tests**
  - Introduced a new test to verify the correct execution and results of correlated subquery UDFs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->