### PR TITLE
Enable basic subquery UDF execution

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,3 @@
+Implemented basic execution for generated subquery UDFs. The UDF now parses the stored SQL, replaces correlated columns with argument values, and executes the resulting query in a new thread with its own Tokio runtime. If the subquery was registered from an EXISTS clause, the closure checks whether any rows are returned and returns a boolean.
+
+Added integration test `subquery_udf_exec` demonstrating execution using two small in-memory tables.


### PR DESCRIPTION
## Summary
- implement execution logic for generated UDFs
- run subquery with replaced parameters inside a dedicated runtime
- treat SELECT EXISTS subqueries specially
- add integration test exercising UDF execution

## Testing
- `cargo test --no-run`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683d8e8e25a4832f8b7991b07e48a8ab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled execution of user-defined functions (UDFs) for correlated subqueries, including support for EXISTS subqueries.
  - UDFs now dynamically substitute argument values and execute subqueries asynchronously.

- **Tests**
  - Added an integration test to demonstrate and verify execution of subquery UDFs with sample in-memory tables.

- **Documentation**
  - Updated documentation to describe the new execution capabilities for subquery UDFs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

Implements core UDF execution functionality for subqueries in DataFusion, enabling dynamic SQL execution with parameter substitution and proper type handling.

- Added complete UDF execution logic in `src/lib.rs` replacing NotImplemented placeholder, with type-safe parameter substitution and NULL handling
- Implemented special optimization path for EXISTS subqueries in `src/lib.rs` to efficiently handle boolean existence checks
- Added concurrent execution support using isolated Tokio runtime for subquery evaluation
- Added new `NOTES.md` documenting implementation details and design decisions
- Added integration tests validating UDF functionality with in-memory tables



<!-- /greptile_comment -->