### PR TITLE
Adjust runtime for big query test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -964,7 +964,7 @@ mod tests {
     }
 
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn run_big_query_2() -> datafusion::error::Result<()> {
         let mut ctx = SessionContext::new();
         register_example_data(&mut ctx).await?;


### PR DESCRIPTION
## Summary
- run `run_big_query_2` under a multi-thread tokio runtime

## Testing
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_684024aaa9ac832f87ce14972b97bc26

<!-- greptile_comment -->

## Greptile Summary

Modified the runtime configuration in `src/lib.rs` to address a deadlock issue in the `run_big_query_2` test by switching from single-threaded to multi-threaded tokio runtime.

- Changed test runtime in `src/lib.rs` to use tokio's multi-threaded runtime with 2 worker threads for improved concurrency handling
- Helps prevent potential deadlocks during complex SQL query transformations and DataFusion query execution



<!-- /greptile_comment -->